### PR TITLE
feat(api): implémenter le service des tâches avec les opérations CRUD

### DIFF
--- a/src/tasks/task.controller.ts
+++ b/src/tasks/task.controller.ts
@@ -1,0 +1,60 @@
+import { Controller, Get, Post, Body, Param, Put, Delete } from '@nestjs/common';
+import { TasksService } from './tasks.service';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
+
+/**
+  Contrôleur responsable de gérer les routes liées aux tâches.
+  Il reçoit les requêtes HTTP et délègue la logique métier au TasksService.
+*/
+@Controller('tasks')
+export class TasksController {
+  constructor(private readonly tasksService: TasksService) {}
+
+  /**
+    Route POST /tasks
+    Permet de créer une nouvelle tâche.
+    Les données reçues dans le corps de la requête sont validées via CreateTaskDto.
+  */
+  @Post()
+  create(@Body() createTaskDto: CreateTaskDto) {
+    return this.tasksService.create(createTaskDto);
+  }
+
+  /**
+    Route GET /tasks
+    Retourne la liste de toutes les tâches.
+  */
+  @Get()
+  findAll() {
+    return this.tasksService.findAll();
+  }
+
+  /**
+    Route GET /tasks/:id
+    Récupère une tâche spécifique via son identifiant.
+  */
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.tasksService.findOne(id);
+  }
+
+  /**
+    Route PUT /tasks/:id
+    Met à jour une tâche existante.
+    Les données envoyées sont validées via UpdateTaskDto.
+  */
+  @Put(':id')
+  update(@Param('id') id: string, @Body() updateTaskDto: UpdateTaskDto) {
+    return this.tasksService.update(id, updateTaskDto);
+  }
+
+  /**
+    Route DELETE /tasks/:id
+    Supprime une tâche en fonction de son identifiant.
+  */
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.tasksService.remove(id);
+  }
+}

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Task, TaskDocument } from './schemas/task.schema';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
+
+@Injectable()
+export class TasksService {
+  constructor(
+    // Injection du modèle Mongoose associé à Task
+    @InjectModel(Task.name) // <= IMPORTANT
+    private readonly taskModel: Model<TaskDocument>,
+  ) {}
+
+  create(createTaskDto: CreateTaskDto) {
+    const created = new this.taskModel(createTaskDto);
+    return created.save();
+  }
+
+  findAll() {
+    return this.taskModel.find().exec();
+  }
+
+  async findOne(id: string) {
+    const task = await this.taskModel.findById(id).exec();
+    if (!task) throw new NotFoundException('Task not found');
+    return task;
+  }
+
+  async update(id: string, updateTaskDto: UpdateTaskDto) {
+    const updated = await this.taskModel
+      .findByIdAndUpdate(id, updateTaskDto, { new: true })
+      .exec();
+    if (!updated) throw new NotFoundException('Task not found');
+    return updated;
+  }
+
+  async remove(id: string) {
+    const res = await this.taskModel.findByIdAndDelete(id).exec();
+    if (!res) throw new NotFoundException('Task not found');
+    return res;
+  }
+}


### PR DESCRIPTION
Cette pull request ajoute la logique métier du service des tâches. 
Elle introduit l'ensemble des opérations CRUD permettant de :

- créer une nouvelle tâche,
- récupérer toutes les tâches,
- récupérer une tâche via son ID,
- mettre à jour une tâche existante,
- supprimer une tâche.

Le service utilise le modèle Mongoose associé pour interagir avec la base de données,
et gère les cas d'erreur avec des exceptions adaptées.

Closed #3 